### PR TITLE
docs(dotnet): add note about reuse of ConfidentialClient. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ namespace Example
     {
         static async Task Main(string[] args)
         {
+            // The ConfidentialClient instance should be reused in production environments.
             ConfidentialClient confidentialClient = await ConfidentialClient.CreateAsync("./path/to/config.json");
             string token = await confidentialClient.GetAccessTokenAsync();
 
@@ -77,6 +78,7 @@ Each helper class in the module has the following features:
 * Accepts a `Configuration` instance that contains information about the OAuth 2.0 client, including the client ID and private key.
 * Performs authentication with FactSet's OAuth 2.0 authorization server and retrieves an access token.
 * Caches the access token for reuse and requests a new access token as needed when one expires.
+    * In order for this to work correctly, the helper class instance should be reused in production environments.
 
 #### Configuration
 


### PR DESCRIPTION
### Description
Added a comment just above the instantiation of the ConfidentialClient,
and under the Authentication section as well, mentioning that the instance can be reused.



<!--
Replace this comment block with detailed description detailed description
of **what** is being changed and **why**.

Here's an example of a good change description:

Added the ability to notify users when a new blog post is made
so that users can be made aware of new features as they become
available.

Used the subscription module to allow users to subscribe to
the various product categories that they are interested in. Emails
are being sent using the smtp module, configured to use FactSet's
standard smtp server.
-->

### Links
ENSC-574

<!--
Replace this comment block with relevant links to project trackers,
like Jira, RPD or GitHub here. Example:

* Fixes #1
* Fixes #2
-->

### Testing

<!--
Replace this comment block with any testing instructions for reviewers. This is in
addition to any acceptance criteria in an associated issue.
-->

### Checklist

Ensure the following things have been met before requesting a review:

* [x] Follows all project developer guide and coding standards.
* [x] Tests have been written for the change, when applicable.
* [x] Confidential information (credentials, auth tokens, etc...) is not included.
