### PR TITLE
chore: use latest Newtonsoft.Json package version 

### DIFF
--- a/src/FactSet.SDK.Utils/FactSet.SDK.Utils.csproj
+++ b/src/FactSet.SDK.Utils/FactSet.SDK.Utils.csproj
@@ -20,7 +20,7 @@
   <ItemGroup>
     <PackageReference Include="IdentityModel" Version="6.2.0" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.32.3" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.*" />
     <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.32.3" />
     <None Include="../../README.md" Pack="true" PackagePath="\" />


### PR DESCRIPTION
### Description

Use `<PackageReference Include="Newtonsoft.Json" Version="13.*" />` to select latest Newtonsoft.Json library version.

### Links

### Testing

### Checklist

Ensure the following things have been met before requesting a review:

* [x] Follows all project developer guide and coding standards.
* [x] Tests have been written for the change, when applicable.
* [x] Confidential information (credentials, auth tokens, etc...) is not included.
